### PR TITLE
missing variable "fileselector_width"

### DIFF
--- a/gui/devices/1920x1200/res/ui.xml
+++ b/gui/devices/1920x1200/res/ui.xml
@@ -161,6 +161,7 @@
 		<variable name="fileselector_highlight_color" value="#505050" />
 		<variable name="fileselector_highlight_font_color" value="#33B5E5" />
 		<variable name="fileselector_spacing" value="18" />
+		<variable name="fileselector_width" value="800" />
 		<variable name="fastscroll_linecolor" value="#50505080" />
 		<variable name="fastscroll_rectcolor" value="#33B5E580" />
 		<variable name="fastscroll_w" value="60" />


### PR DESCRIPTION
add missing variable to fix "MultiROM - ROM list" page in landscape mode (hdpi)
https://github.com/Tasssadar/Team-Win-Recovery-Project/blob/master/gui/devices/landscape/res/multirom.xml#L163