### PR TITLE
minuitwrp: pixelflinger no longer has VectorImpl

### DIFF
--- a/minuitwrp/Android.mk
+++ b/minuitwrp/Android.mk
@@ -157,7 +157,7 @@ ifneq ($(TW_THEME_LANDSCAPE),)
   LOCAL_CFLAGS += -DTW_HAS_LANDSCAPE
 endif
 
-LOCAL_SHARED_LIBRARIES += libz libc libcutils libjpeg libpng
+LOCAL_SHARED_LIBRARIES += libz libc libcutils libjpeg libpng libutils
 LOCAL_STATIC_LIBRARIES += libpixelflinger_static
 LOCAL_MODULE_TAGS := eng
 LOCAL_MODULE := libminuitwrp


### PR DESCRIPTION
after latest google CVE. So add libutils

Fixes broken build on Omni 5.1 tree after this change: https://github.com/omnirom/android_system_core/commit/0caf529a2faf3eff5d92729d6996013a24918973 was merged.

Change-Id: I86e0c8a23018fae1c4097a9993c8fa7dbbb7c64e
