### PR TITLE
Fix errors when compiling the TWRP android-6.0 branch on aosp 6.0 base

### DIFF
--- a/multirom/cp_xattrs/Android.mk
+++ b/multirom/cp_xattrs/Android.mk
@@ -4,16 +4,32 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := libcp_xattrs.cpp
 LOCAL_MODULE := libcp_xattrs
 LOCAL_MODULE_TAGS := eng
-LOCAL_SHARED_LIBRARIES += libc libstlport
-LOCAL_C_INCLUDES += bionic external/stlport/stlport
+LOCAL_SHARED_LIBRARIES += libc
+ifeq ($(shell test $(PLATFORM_SDK_VERSION) -lt 23; echo $$?),0)
+    LOCAL_SHARED_LIBRARIES += libstlport
+else
+    LOCAL_SHARED_LIBRARIES += libc++
+endif
+LOCAL_C_INCLUDES += bionic
+ifeq ($(shell test $(PLATFORM_SDK_VERSION) -lt 23; echo $$?),0)
+    LOCAL_C_INCLUDES += external/stlport/stlport
+endif
 include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
 LOCAL_SRC_FILES := cp_xattrs.cpp
 LOCAL_MODULE := cp_xattrs
 LOCAL_MODULE_TAGS := eng
-LOCAL_C_INCLUDES += bionic external/stlport/stlport
-LOCAL_SHARED_LIBRARIES += libc libstlport
+LOCAL_C_INCLUDES += bionic
+ifeq ($(shell test $(PLATFORM_SDK_VERSION) -lt 23; echo $$?),0)
+    LOCAL_C_INCLUDES += external/stlport/stlport
+endif
+LOCAL_SHARED_LIBRARIES += libc
+ifeq ($(shell test $(PLATFORM_SDK_VERSION) -lt 23; echo $$?),0)
+    LOCAL_SHARED_LIBRARIES += libstlport
+else
+    LOCAL_SHARED_LIBRARIES += libc++
+endif
 LOCAL_STATIC_LIBRARIES += libcp_xattrs
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
 LOCAL_UNSTRIPPED_PATH := $(TARGET_OUT_EXECUTABLES_UNSTRIPPED)
@@ -23,8 +39,16 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := ls_xattrs.cpp
 LOCAL_MODULE := ls_xattrs
 LOCAL_MODULE_TAGS := eng
-LOCAL_C_INCLUDES += bionic external/stlport/stlport
-LOCAL_SHARED_LIBRARIES += libc libstlport
+LOCAL_C_INCLUDES += bionic
+ifeq ($(shell test $(PLATFORM_SDK_VERSION) -lt 23; echo $$?),0)
+    LOCAL_C_INCLUDES += external/stlport/stlport
+endif
+LOCAL_SHARED_LIBRARIES += libc
+ifeq ($(shell test $(PLATFORM_SDK_VERSION) -lt 23; echo $$?),0)
+    LOCAL_SHARED_LIBRARIES += libstlport
+else
+    LOCAL_SHARED_LIBRARIES += libc++
+endif
 LOCAL_STATIC_LIBRARIES += libcp_xattrs
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
 LOCAL_UNSTRIPPED_PATH := $(TARGET_OUT_EXECUTABLES_UNSTRIPPED)

--- a/multirom/cp_xattrs/libcp_xattrs.cpp
+++ b/multirom/cp_xattrs/libcp_xattrs.cpp
@@ -7,6 +7,7 @@
 #include <linux/xattr.h>
 #include <sys/xattr.h>
 #include <sys/vfs.h>
+#include <errno.h>
 
 #include "libcp_xattrs.h"
 

--- a/multirom/multirom.cpp
+++ b/multirom/multirom.cpp
@@ -2185,7 +2185,7 @@ const base_folder& MultiROM::addBaseFolder(const std::string& name, int min, int
 const base_folder& MultiROM::addBaseFolder(const base_folder& b)
 {
 	LOGINFO("MROMInstaller: base folder: %s (min: %dMB def: %dMB)\n", b.name.c_str(), b.min_size, b.size);
-	return m_base_folders.insert(std::make_pair<std::string, base_folder>(b.name, b)).first->second;
+	return m_base_folders.insert(std::make_pair(b.name, b)).first->second;
 }
 
 MultiROM::baseFolders& MultiROM::getBaseFolders()


### PR DESCRIPTION
This is an update to pull request #21. There were some compiler errors when building on the android-6.0 base. 

The first two issues below are minor things addressed in one commit. I'm not sure if it's acceptable this way. 
The third issue is in a separate commit. It is that aosp does not use stlport anymore since Marshmallow.

1. libcp_xattrs.cpp needs to include errno.h otherwise there are undefined errors where the errno macro is used.

2. In MultiROM::addBaseFolder() in multirom.cpp. Don't explicitly specify the template arguments for std::make_pair

3. libcp_xattrs on Android SDK 23 needs to be linked against libc++ instead of libstlport. There isn't an libstlport in Marshmallow source. The way the SDK version check is done was referenced from the root TWRP makefile.  

I have succesfully compiled and booted up TWRP with these two patches on android-5.0.2_r1 and android 6.0.1_r11 base.