### PR TITLE
fix build warning of using c++ when build multirom.cpp

### DIFF
--- a/gui/action.cpp
+++ b/gui/action.cpp
@@ -2605,7 +2605,7 @@ int GUIAction::system_image_upgrader(std::string arg)
 	if(TWFunc::Path_Exists(UBUNTU_COMMAND_FILE))
 	{
 		gui_print("\n");
-		res = TWFunc::Exec_Cmd_Show_Output("system-image-upgrader "UBUNTU_COMMAND_FILE);
+		res = TWFunc::Exec_Cmd_Show_Output("system-image-upgrader " UBUNTU_COMMAND_FILE);
 		gui_print("\n");
 
 		if(res != 0)
@@ -2615,7 +2615,7 @@ int GUIAction::system_image_upgrader(std::string arg)
 		}
 		DataManager::SetValue("system-image-upgrader-res", res);
 	} else
-		gui_print("Could not find system-image-upgrader command file: "UBUNTU_COMMAND_FILE"\n");
+		gui_print("Could not find system-image-upgrader command file: " UBUNTU_COMMAND_FILE "\n");
 
 	DataManager::SetValue("tw_page_done", 1);
 	operation_end(res);

--- a/multirom/multirom.cpp
+++ b/multirom/multirom.cpp
@@ -48,9 +48,8 @@ MROMInstaller *MultiROM::m_installer = NULL;
 MultiROM::baseFolders MultiROM::m_base_folders;
 int MultiROM::m_base_folder_cnt = 0;
 bool MultiROM::m_has_firmware = false;
-std::string    MultiROM::tmp_str = "";
-std::string   MultiROM::MR_UPDATE_SCRIPT_PATH ="META-INF/com/google/android/";
-std::string   MultiROM::MR_UPDATE_SCRIPT_NAME  =  "META-INF/com/google/android/updater-script";
+#define MR_UPDATE_SCRIPT_PATH   "META-INF/com/google/android/"
+#define MR_UPDATE_SCRIPT_NAME   "META-INF/com/google/android/updater-script"
 
 base_folder::base_folder(const std::string& name, int min_size, int size)
 {
@@ -182,8 +181,8 @@ bool MultiROM::setRomsPath(std::string loc)
 		return false;
 	}
 
-    m_curr_roms_path = "/mnt/multirom-"  + (string)TARGET_DEVICE + "/";
-    mkdir(m_curr_roms_path.c_str(), 0777);
+    	m_curr_roms_path = "/mnt/multirom-"  TARGET_DEVICE  "/";
+    	mkdir(m_curr_roms_path.c_str(), 0777);
 	return true;
 }
 
@@ -954,17 +953,15 @@ bool MultiROM::flashZip(std::string rom, std::string file)
 	DataManager::SetValue(TW_SIGNED_ZIP_VERIFY_VAR, 0);
 	status = TWinstall_zip(file.c_str(), &wipe_cache);
 	DataManager::SetValue(TW_SIGNED_ZIP_VERIFY_VAR, verify_status);
-    tmp_str = "/tmp" + MR_UPDATE_SCRIPT_NAME;
-    if(restore_script && hacker.restoreState() && hacker.writeToFile(tmp_str))
+    	if(restore_script && hacker.restoreState() && hacker.writeToFile("tmp" MR_UPDATE_SCRIPT_NAME))
 	{
 		gui_print("Restoring original updater-script\n");
-        if(system_args("cd /tmp && zip \"%s\" %s", file.c_str(), MR_UPDATE_SCRIPT_NAME.c_str()) != 0)
+        if(system_args("cd /tmp && zip \"%s\" %s", file.c_str(), MR_UPDATE_SCRIPT_NAME) != 0)
 			LOGERR("Failed to restore original updater-script, THIS ZIP IS NOW UNUSEABLE FOR NON-MULTIROM FLASHING\n");
 	}
 
 
-    tmp_str = "rm -rf" + MR_UPDATE_SCRIPT_PATH;
-    system(tmp_str.c_str());
+    system("rm -rf" MR_UPDATE_SCRIPT_PATH);
 	if(file == "/tmp/mr_update.zip")
 		system("rm /tmp/mr_update.zip");
 
@@ -1015,15 +1012,14 @@ bool MultiROM::flashORSZip(std::string file, int *wipe_cache)
 	DataManager::SetValue(TW_SIGNED_ZIP_VERIFY_VAR, 0);
 	status = TWinstall_zip(file.c_str(), wipe_cache);
 	DataManager::SetValue(TW_SIGNED_ZIP_VERIFY_VAR, verify_status);
-    std::string update_script_tmp = "/tmp" + MR_UPDATE_SCRIPT_NAME;
-    if(restore_script && hacker.restoreState() && hacker.writeToFile(update_script_tmp))
+    	if(restore_script && hacker.restoreState() && hacker.writeToFile("tmp" MR_UPDATE_SCRIPT_NAME))
 	{
 		gui_print("Restoring original updater-script\n");
-        if(system_args("cd /tmp && zip \"%s\" %s", file.c_str(), MR_UPDATE_SCRIPT_NAME.c_str()) != 0)
+        if(system_args("cd /tmp && zip \"%s\" %s", file.c_str(), MR_UPDATE_SCRIPT_NAME)  != 0)
 			LOGERR("Failed to restore original updater-script, THIS ZIP IS NOW UNUSEABLE FOR NON-MULTIROM FLASHING\n");
 	}
-    update_script_tmp = "rm -rf" + MR_UPDATE_SCRIPT_PATH;
-    system(update_script_tmp.c_str());
+
+    system("rm -rf" MR_UPDATE_SCRIPT_PATH);
 	if(file == "/tmp/mr_update.zip")
 		system("rm /tmp/mr_update.zip");
 
@@ -1082,7 +1078,7 @@ bool MultiROM::prepareZIP(std::string& file, EdifyHacker *hacker, bool& restore_
 		return false;
 	}
 
-    system_args("mkdir -p /tmp/%s", MR_UPDATE_SCRIPT_PATH.c_str());
+    system_args("mkdir -p /tmp/%s", MR_UPDATE_SCRIPT_PATH);
 
 	MemMapping map;
 	if (sysMapFile(file.c_str(), &map) != 0) {
@@ -1097,10 +1093,10 @@ bool MultiROM::prepareZIP(std::string& file, EdifyHacker *hacker, bool& restore_
 		goto exit;
 	}
 
-    script_entry = mzFindZipEntry(&zip, MR_UPDATE_SCRIPT_NAME.c_str());
+    script_entry = mzFindZipEntry(&zip, MR_UPDATE_SCRIPT_NAME);
 	if(!script_entry)
 	{
-        gui_print("Failed to find entry %s in ZIP file %s!\n", MR_UPDATE_SCRIPT_NAME.c_str(),file.c_str());
+        gui_print("Failed to find entry %s in ZIP file %s!\n", MR_UPDATE_SCRIPT_NAME ,file.c_str());
 		goto exit;
 	}
 
@@ -1124,8 +1120,7 @@ bool MultiROM::prepareZIP(std::string& file, EdifyHacker *hacker, bool& restore_
 
 	hacker->saveState();
 	hacker->replaceOffendings();
-   tmp_str = "/tmp/" + MR_UPDATE_SCRIPT_NAME;
-    if(!hacker->writeToFile(tmp_str.c_str()))
+    	if(!hacker->writeToFile("tmp" MR_UPDATE_SCRIPT_NAME))
 		goto exit;
 
 	hacker->writeToFile("/tmp/mrom_last_updater_script");
@@ -1169,7 +1164,7 @@ bool MultiROM::prepareZIP(std::string& file, EdifyHacker *hacker, bool& restore_
 			restore_script = true;
 		}
 
-        if(system_args("cd /tmp && zip \"%s\" %s", file.c_str(), MR_UPDATE_SCRIPT_NAME.c_str()) != 0)
+        	if(system_args("cd /tmp && zip \"%s\" %s", file.c_str(), MR_UPDATE_SCRIPT_NAME ) != 0)
 		{
 			system("rm /tmp/mr_update.zip");
 			return false;
@@ -2678,7 +2673,7 @@ void MultiROM::executeCacheScripts()
 			if(stat((path + SCRIPT_FILE_CACHE).c_str(), &info) < 0)
 				continue;
 
-            if(info.st_mtime > (signed int)script.mtime)
+            	if(info.st_mtime > (signed int)script.mtime)
 			{
 				script.mtime = info.st_mtime;
 				script.name = dt->d_name;
@@ -2690,7 +2685,7 @@ void MultiROM::executeCacheScripts()
 			if(stat((path + UBUNTU_COMMAND_FILE).c_str(), &info) < 0)
 				continue;
 
-            if(info.st_mtime > (signed int)script.mtime)
+            	if(info.st_mtime > (signed int)script.mtime)
 			{
 				script.mtime = info.st_mtime;
 				script.name = dt->d_name;

--- a/multirom/multirom.cpp
+++ b/multirom/multirom.cpp
@@ -38,6 +38,8 @@ extern "C" {
 #include "../libblkid/include/blkid.h"
 #include "cp_xattrs/libcp_xattrs.h"
 
+#include <string>
+
 std::string MultiROM::m_path = "";
 std::string MultiROM::m_boot_dev = "";
 std::string MultiROM::m_mount_rom_paths[2] = { "", "" };
@@ -46,6 +48,9 @@ MROMInstaller *MultiROM::m_installer = NULL;
 MultiROM::baseFolders MultiROM::m_base_folders;
 int MultiROM::m_base_folder_cnt = 0;
 bool MultiROM::m_has_firmware = false;
+std::string    MultiROM::tmp_str = "";
+std::string   MultiROM::MR_UPDATE_SCRIPT_PATH ="META-INF/com/google/android/";
+std::string   MultiROM::MR_UPDATE_SCRIPT_NAME  =  "META-INF/com/google/android/updater-script";
 
 base_folder::base_folder(const std::string& name, int min_size, int size)
 {
@@ -177,8 +182,8 @@ bool MultiROM::setRomsPath(std::string loc)
 		return false;
 	}
 
-	m_curr_roms_path = "/mnt/multirom-"TARGET_DEVICE"/";
-	mkdir("/mnt/multirom-"TARGET_DEVICE"/", 0777);
+    m_curr_roms_path = "/mnt/multirom-"  + (string)TARGET_DEVICE + "/";
+    mkdir(m_curr_roms_path.c_str(), 0777);
 	return true;
 }
 
@@ -901,8 +906,6 @@ bool MultiROM::createFakeSystemImg()
 	return true;
 }
 
-#define MR_UPDATE_SCRIPT_PATH  "META-INF/com/google/android/"
-#define MR_UPDATE_SCRIPT_NAME  "META-INF/com/google/android/updater-script"
 
 bool MultiROM::flashZip(std::string rom, std::string file)
 {
@@ -951,15 +954,17 @@ bool MultiROM::flashZip(std::string rom, std::string file)
 	DataManager::SetValue(TW_SIGNED_ZIP_VERIFY_VAR, 0);
 	status = TWinstall_zip(file.c_str(), &wipe_cache);
 	DataManager::SetValue(TW_SIGNED_ZIP_VERIFY_VAR, verify_status);
-
-	if(restore_script && hacker.restoreState() && hacker.writeToFile("/tmp/"MR_UPDATE_SCRIPT_NAME))
+    tmp_str = "/tmp" + MR_UPDATE_SCRIPT_NAME;
+    if(restore_script && hacker.restoreState() && hacker.writeToFile(tmp_str))
 	{
 		gui_print("Restoring original updater-script\n");
-		if(system_args("cd /tmp && zip \"%s\" %s", file.c_str(), MR_UPDATE_SCRIPT_NAME) != 0)
+        if(system_args("cd /tmp && zip \"%s\" %s", file.c_str(), MR_UPDATE_SCRIPT_NAME.c_str()) != 0)
 			LOGERR("Failed to restore original updater-script, THIS ZIP IS NOW UNUSEABLE FOR NON-MULTIROM FLASHING\n");
 	}
 
-	system("rm -r "MR_UPDATE_SCRIPT_PATH);
+
+    tmp_str = "rm -rf" + MR_UPDATE_SCRIPT_PATH;
+    system(tmp_str.c_str());
 	if(file == "/tmp/mr_update.zip")
 		system("rm /tmp/mr_update.zip");
 
@@ -1010,15 +1015,15 @@ bool MultiROM::flashORSZip(std::string file, int *wipe_cache)
 	DataManager::SetValue(TW_SIGNED_ZIP_VERIFY_VAR, 0);
 	status = TWinstall_zip(file.c_str(), wipe_cache);
 	DataManager::SetValue(TW_SIGNED_ZIP_VERIFY_VAR, verify_status);
-
-	if(restore_script && hacker.restoreState() && hacker.writeToFile("/tmp/"MR_UPDATE_SCRIPT_NAME))
+    std::string update_script_tmp = "/tmp" + MR_UPDATE_SCRIPT_NAME;
+    if(restore_script && hacker.restoreState() && hacker.writeToFile(update_script_tmp))
 	{
 		gui_print("Restoring original updater-script\n");
-		if(system_args("cd /tmp && zip \"%s\" %s", file.c_str(), MR_UPDATE_SCRIPT_NAME) != 0)
+        if(system_args("cd /tmp && zip \"%s\" %s", file.c_str(), MR_UPDATE_SCRIPT_NAME.c_str()) != 0)
 			LOGERR("Failed to restore original updater-script, THIS ZIP IS NOW UNUSEABLE FOR NON-MULTIROM FLASHING\n");
 	}
-
-	system("rm -r "MR_UPDATE_SCRIPT_PATH);
+    update_script_tmp = "rm -rf" + MR_UPDATE_SCRIPT_PATH;
+    system(update_script_tmp.c_str());
 	if(file == "/tmp/mr_update.zip")
 		system("rm /tmp/mr_update.zip");
 
@@ -1077,7 +1082,7 @@ bool MultiROM::prepareZIP(std::string& file, EdifyHacker *hacker, bool& restore_
 		return false;
 	}
 
-	system_args("mkdir -p /tmp/%s", MR_UPDATE_SCRIPT_PATH);
+    system_args("mkdir -p /tmp/%s", MR_UPDATE_SCRIPT_PATH.c_str());
 
 	MemMapping map;
 	if (sysMapFile(file.c_str(), &map) != 0) {
@@ -1092,10 +1097,10 @@ bool MultiROM::prepareZIP(std::string& file, EdifyHacker *hacker, bool& restore_
 		goto exit;
 	}
 
-	script_entry = mzFindZipEntry(&zip, MR_UPDATE_SCRIPT_NAME);
+    script_entry = mzFindZipEntry(&zip, MR_UPDATE_SCRIPT_NAME.c_str());
 	if(!script_entry)
 	{
-		gui_print("Failed to find entry "MR_UPDATE_SCRIPT_NAME" in ZIP file %s!\n", file.c_str());
+        gui_print("Failed to find entry %s in ZIP file %s!\n", MR_UPDATE_SCRIPT_NAME.c_str(),file.c_str());
 		goto exit;
 	}
 
@@ -1119,8 +1124,8 @@ bool MultiROM::prepareZIP(std::string& file, EdifyHacker *hacker, bool& restore_
 
 	hacker->saveState();
 	hacker->replaceOffendings();
-
-	if(!hacker->writeToFile("/tmp/"MR_UPDATE_SCRIPT_NAME))
+   tmp_str = "/tmp/" + MR_UPDATE_SCRIPT_NAME;
+    if(!hacker->writeToFile(tmp_str.c_str()))
 		goto exit;
 
 	hacker->writeToFile("/tmp/mrom_last_updater_script");
@@ -1164,7 +1169,7 @@ bool MultiROM::prepareZIP(std::string& file, EdifyHacker *hacker, bool& restore_
 			restore_script = true;
 		}
 
-		if(system_args("cd /tmp && zip \"%s\" %s", file.c_str(), MR_UPDATE_SCRIPT_NAME) != 0)
+        if(system_args("cd /tmp && zip \"%s\" %s", file.c_str(), MR_UPDATE_SCRIPT_NAME.c_str()) != 0)
 		{
 			system("rm /tmp/mr_update.zip");
 			return false;
@@ -2673,7 +2678,7 @@ void MultiROM::executeCacheScripts()
 			if(stat((path + SCRIPT_FILE_CACHE).c_str(), &info) < 0)
 				continue;
 
-			if(info.st_mtime > script.mtime)
+            if(info.st_mtime > (signed int)script.mtime)
 			{
 				script.mtime = info.st_mtime;
 				script.name = dt->d_name;
@@ -2685,7 +2690,7 @@ void MultiROM::executeCacheScripts()
 			if(stat((path + UBUNTU_COMMAND_FILE).c_str(), &info) < 0)
 				continue;
 
-			if(info.st_mtime > script.mtime)
+            if(info.st_mtime > (signed int)script.mtime)
 			{
 				script.mtime = info.st_mtime;
 				script.name = dt->d_name;

--- a/multirom/multirom.h
+++ b/multirom/multirom.h
@@ -55,7 +55,9 @@ enum
 #define INTERNAL_MEM_LOC_TXT "Internal memory"
 
 // Not defined in android includes?
+#ifndef MS_RELATIME
 #define MS_RELATIME (1<<21)
+#endif
 
 #define MAX_BASE_FOLDER_CNT 5
 
@@ -189,6 +191,11 @@ public:
 
 	static std::string getRecoveryVersion();
 
+public:
+static    std::string tmp_str;
+static    std::string  MR_UPDATE_SCRIPT_PATH;
+static    std::string  MR_UPDATE_SCRIPT_NAME;
+
 private:
 	static void findPath();
 	static bool changeMounts(std::string base);
@@ -234,6 +241,7 @@ private:
 	static int m_base_folder_cnt;
 	static std::string m_boot_dev;
 	static bool m_has_firmware;
+
 };
 
 

--- a/multirom/multirom.h
+++ b/multirom/multirom.h
@@ -191,11 +191,6 @@ public:
 
 	static std::string getRecoveryVersion();
 
-public:
-static    std::string tmp_str;
-static    std::string  MR_UPDATE_SCRIPT_PATH;
-static    std::string  MR_UPDATE_SCRIPT_NAME;
-
 private:
 	static void findPath();
 	static bool changeMounts(std::string base);

--- a/prebuilt/Android.mk
+++ b/prebuilt/Android.mk
@@ -177,6 +177,9 @@ ifeq ($(TARGET_USERIMAGES_USE_F2FS), true)
     ifeq ($(shell test $(CM_PLATFORM_SDK_VERSION) -ge 4; echo $$?),0)
         RELINK_SOURCE_FILES += $(TARGET_OUT_EXECUTABLES)/mkfs.f2fs
         RELINK_SOURCE_FILES += $(TARGET_OUT_SHARED_LIBRARIES)/libf2fs.so
+    else ifeq ($(shell test $(MK_PLATFORM_SDK_VERSION) -ge 4; echo $$?),0)
+	RELINK_SOURCE_FILES += $(TARGET_OUT_EXECUTABLES)/mkfs.f2fs
+	RELINK_SOURCE_FILES += $(TARGET_OUT_EXECUTABLES)/fsck.f2fs
     else ifneq (,$(filter $(PLATFORM_SDK_VERSION), 23))
         RELINK_SOURCE_FILES += $(TARGET_RECOVERY_ROOT_OUT)/sbin/mkfs.f2fs
     else ifneq (,$(filter $(PLATFORM_SDK_VERSION), 21 22))

--- a/toolbox/Android.mk
+++ b/toolbox/Android.mk
@@ -43,28 +43,20 @@ ifeq ($(TW_USE_TOOLBOX), true)
         # These are the only toolbox tools in M. The rest are now in toybox.
         BSD_TOOLS := \
             dd \
-            du \
 
         OUR_TOOLS := \
-            df \
             iftop \
             ioctl \
-            ionice \
             log \
             ls \
-            lsof \
-            mount \
             nandread \
             newfs_msdos \
             ps \
             prlimit \
-            renice \
             sendevent \
             start \
             stop \
             top \
-            uptime \
-            watchprops \
 
     else
         ifneq (,$(filter $(PLATFORM_SDK_VERSION), 21 22))
@@ -213,17 +205,17 @@ ifneq (,$(filter $(PLATFORM_SDK_VERSION), 21 22 23))
     LOCAL_WHOLE_STATIC_LIBRARIES := $(patsubst %,libtoolbox_%,$(BSD_TOOLS))
 endif
 
-ifeq ($(shell test $(PLATFORM_SDK_VERSION) -gt 22; echo $$?),0)
-    # Rule to make getprop and setprop in M trees where toybox normally
-    # provides these tools. Toybox does not allow for easy dynamic
-    # configuration, so we would have to include the entire toybox binary
-    # which takes up more space than is necessary so long as we are still
-    # including busybox.
-    LOCAL_SRC_FILES += \
-        ../../../$(TWRP_TOOLBOX_PATH)/getprop.c \
-        ../../../$(TWRP_TOOLBOX_PATH)/setprop.c
-    OUR_TOOLS += getprop setprop
-    ifneq ($(TW_USE_TOOLBOX), true)
+ifneq ($(TW_USE_TOOLBOX), true)
+    ifeq ($(shell test $(PLATFORM_SDK_VERSION) -le 22; echo $$?),0)
+        # Rule to make getprop and setprop in M trees where toybox normally
+        # provides these tools. Toybox does not allow for easy dynamic
+        # configuration, so we would have to include the entire toybox binary
+        # which takes up more space than is necessary so long as we are still
+        # including busybox.
+        LOCAL_SRC_FILES += \
+            ../../../$(TWRP_TOOLBOX_PATH)/getprop.c \
+            ../../../$(TWRP_TOOLBOX_PATH)/setprop.c
+        OUR_TOOLS += getprop setprop
         LOCAL_SRC_FILES += ls.c
     endif
 endif

--- a/toybox/Android.mk
+++ b/toybox/Android.mk
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2014 The Android Open Source Project
+# Copyright (C) 2015 Mokee Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,8 +58,10 @@ LOCAL_SRC_FILES := \
     lib/help.c \
     lib/interestingtimes.c \
     lib/lib.c \
+    lib/linestack.c \
     lib/llist.c \
     lib/net.c \
+    lib/password.c \
     lib/portability.c \
     lib/xwrap.c \
     main.c \
@@ -90,13 +93,16 @@ LOCAL_SRC_FILES := \
     toys/other/clear.c \
     toys/other/dos2unix.c \
     toys/other/fallocate.c \
+    toys/other/flock.c \
     toys/other/free.c \
     toys/other/freeramdisk.c \
     toys/other/fsfreeze.c \
     toys/other/help.c \
+    toys/other/hwclock.c \
     toys/other/ifconfig.c \
     toys/other/inotifyd.c \
     toys/other/insmod.c \
+    toys/other/ionice.c \
     toys/other/losetup.c \
     toys/other/lsattr.c \
     toys/other/lsmod.c \
@@ -112,8 +118,10 @@ LOCAL_SRC_FILES := \
     toys/other/pmap.c \
     toys/other/printenv.c \
     toys/other/pwdx.c \
+    toys/other/readahead.c \
     toys/other/readlink.c \
     toys/other/realpath.c \
+    toys/other/reset.c \
     toys/other/rev.c \
     toys/other/rfkill.c \
     toys/other/rmmod.c \
@@ -127,22 +135,32 @@ LOCAL_SRC_FILES := \
     toys/other/taskset.c \
     toys/other/timeout.c \
     toys/other/truncate.c \
+    toys/other/uptime.c \
     toys/other/usleep.c \
     toys/other/vconfig.c \
     toys/other/vmstat.c \
     toys/other/which.c \
+    toys/other/xxd.c \
     toys/other/yes.c \
+    toys/pending/arp.c \
     toys/pending/dd.c \
+    toys/pending/diff.c \
     toys/pending/expr.c \
-    toys/pending/hwclock.c \
+    toys/pending/fdisk.c \
+    toys/pending/ftpget.c \
+    toys/pending/host.c \
+    toys/pending/lsof.c \
     toys/pending/more.c \
-    toys/pending/pgrep.c \
     toys/pending/netstat.c \
+    toys/pending/resize.c \
     toys/pending/route.c \
     toys/pending/tar.c \
-    toys/pending/top.c \
+    toys/pending/telnet.c \
+    toys/pending/test.c \
     toys/pending/tr.c \
     toys/pending/traceroute.c \
+    toys/pending/watch.c \
+    toys/pending/xzcat.c \
     toys/posix/basename.c \
     toys/posix/cal.c \
     toys/posix/cat.c \
@@ -178,6 +196,7 @@ LOCAL_SRC_FILES := \
     toys/posix/paste.c \
     toys/posix/patch.c \
     toys/posix/printf.c \
+    toys/posix/ps.c \
     toys/posix/pwd.c \
     toys/posix/renice.c \
     toys/posix/rm.c \
@@ -196,7 +215,7 @@ LOCAL_SRC_FILES := \
     toys/posix/uname.c \
     toys/posix/uniq.c \
     toys/posix/wc.c \
-    toys/posix/xargs.c \
+    toys/posix/xargs.c
 
 LOCAL_CFLAGS += \
     -std=c99 \
@@ -217,14 +236,22 @@ LOCAL_CLANG := true
 
 LOCAL_SHARED_LIBRARIES := libcutils libselinux
 
+# This doesn't actually prevent us from dragging in libc++ at runtime
+# because libnetd_client.so is C++.
+LOCAL_CXX_STL := none
+
+LOCAL_C_INCLUDES += bionic/libc/dns/include
+
 LOCAL_MODULE := toybox_recovery
 LOCAL_MODULE_STEM := toybox
 LOCAL_MODULE_PATH := $(TARGET_RECOVERY_ROOT_OUT)/sbin
 LOCAL_MODULE_TAGS := optional
 
-# dupes: dd df du ls mount renice
-# useless?: freeramdisk fsfreeze install makedevs mkfifo nbd-client
-#           partprobe pivot_root pwdx rev rfkill switch_root tty vconfig
+# dupes: dd ls
+# useless?: arp diff flock freeramdisk fsfreeze ftpget host install
+#           makedevs mkfifo nbd-client partprobe pivot_root pwdx readahead
+#           reset resize rev rfkill switch_root telnet test tty vconfig
+#           watch xxd xzcat
 # prefer BSD netcat instead?: nc netcat
 # prefer efs2progs instead?: blkid chattr lsattr
 
@@ -249,9 +276,11 @@ ALL_TOOLS := \
     cpio \
     cut \
     date \
+    df \
     dirname \
     dmesg \
     dos2unix \
+    du \
     echo \
     env \
     expand \
@@ -262,6 +291,7 @@ ALL_TOOLS := \
     free \
     getenforce \
     getprop \
+    grep \
     groups \
     head \
     hostname \
@@ -270,12 +300,14 @@ ALL_TOOLS := \
     ifconfig \
     inotifyd \
     insmod \
+    ionice \
     kill \
     load_policy \
     ln \
     logname \
     losetup \
     lsmod \
+    lsof \
     lsusb \
     md5sum \
     mkdir \
@@ -284,6 +316,7 @@ ALL_TOOLS := \
     mktemp \
     modinfo \
     more \
+    mount \
     mountpoint \
     mv \
     netstat \
@@ -302,6 +335,7 @@ ALL_TOOLS := \
     pwd \
     readlink \
     realpath \
+    renice \
     restorecon \
     rm \
     rmdir \
@@ -338,13 +372,14 @@ ALL_TOOLS := \
     uname \
     uniq \
     unix2dos \
+    uptime \
     usleep \
     vmstat \
     wc \
     which \
     whoami \
     xargs \
-    yes \
+    yes
 
 # Install the symlinks.
 LOCAL_POST_INSTALL_CMD := $(hide) $(foreach t,$(ALL_TOOLS),ln -sf toybox $(TARGET_RECOVERY_ROOT_OUT)/sbin/$(t);)

--- a/twrp-functions.cpp
+++ b/twrp-functions.cpp
@@ -128,7 +128,7 @@ int TWFunc::Exec_Cmd_Show_Output(const string& cmd) {
 		memset(buffer, 0, sizeof(buffer));
 		if (fgets(buffer, 128, exec) != NULL) {
 			buffer[128] = '\n';
-			buffer[129] = NULL;
+            buffer[129] = '\0';
 			gui_print(buffer);
 		}
 	}

--- a/twrp-functions.cpp
+++ b/twrp-functions.cpp
@@ -128,7 +128,7 @@ int TWFunc::Exec_Cmd_Show_Output(const string& cmd) {
 		memset(buffer, 0, sizeof(buffer));
 		if (fgets(buffer, 128, exec) != NULL) {
 			buffer[128] = '\n';
-            buffer[129] = '\0';
+            		buffer[129] = '\0';
 			gui_print(buffer);
 		}
 	}


### PR DESCRIPTION
fix build warning of using c++  when build multirom.cpp  
1. Test MS_RELATIME if we has define in android source
2. Fix build error when TW_USE_TOOLBOX := true 
3. Fix build issuse of f2fs when build with MoKee Open Source 
4. Fix build warning of twrp-functions.cpp
