### PR TITLE
Add "multirom_storage" partitionlist type

### DIFF
--- a/gui/themes_multirom/1080x1920/light_mr.xml
+++ b/gui/themes_multirom/1080x1920/light_mr.xml
@@ -141,7 +141,7 @@
 			<object type="text" color="%text%">
 				<font resource="body2" />
 				<placement x="%col1_x%" y="%row2_3_y%" />
-				<text>%tw_multirom_install_loc% (%tw_storage_free_size% MB)</text>
+				<text>%tw_multirom_storage_display_name% (%tw_multirom_storage_free_size% MB)</text>
 			</object>
 
 			<object type="button">
@@ -2353,14 +2353,14 @@
 				</actions>
 			</object>
 
-			<object type="listbox">
+			<object type="partitionlist">
 				<fastscroll linecolor="%fastscroll_linecolor%" rectcolor="%fastscroll_rectcolor%" w="%fastscroll_w%" linew="%fastscroll_linew%" rectw="%fastscroll_rectw%" recth="%fastscroll_recth%" />
 				<placement x="%col1_x%" y="%row5_2_y%" w="%content_w%" h="%fileselector_part_height%" />
 				<icon selected="radio_true" unselected="radio_false" />
 				<background color="%background%" />
 				<font resource="body2" spacing="%fileselector_spacing%" color="%text%" highlightcolor="%highlight%" />
-				<data name="tw_multirom_install_loc" />
-				<items>tw_multirom_install_loc_list</items>
+				<data name="tw_multirom_storage_path" />
+				<listtype name="multirom_storage" />
 			</object>
 
 			<object type="text" color="%text_dark%">
@@ -4366,13 +4366,14 @@
 				<image resource="dialog_bg" />
 			</object>
 
-			<object type="listbox">
-				<placement x="%storage_indent_x%" y="%storage_indent_y%" w="%storage_width%" h="%storage_height%" />
+			<object type="partitionlist">
+<!--				<placement x="%storage_indent_x%" y="%storage_indent_y%" w="%storage_width%" h="%storage_height%" /> -->
+				<placement x="%storage_indent_x%" y="%storage_indent_y%" w="%storage_width%" h="%fileselector_wipe_height%" />
 				<icon selected="radio_true_d" unselected="radio_false_d" />
 				<background color="%background%" />
 				<font resource="body2" spacing="0" color="%text%" highlightcolor="%text_highlight%" />
-				<data name="tw_multirom_install_loc" />
-				<items>tw_multirom_install_loc_list</items>
+				<data name="tw_multirom_storage_path" />
+				<listtype name="multirom_storage" />
 			</object>
 
 			<object type="button">

--- a/multirom/CHANGES
+++ b/multirom/CHANGES
@@ -3,20 +3,21 @@ Build flag (in BoardConfig)
 - add TARGET_RECOVERY_IS_MULTIROM := true
   to enable multirom version of twrp
 
-- TODO: check for this flag in system/extras/multirom
-  and libbootimg, and disable building them if the flag
-  is not set, otherwise multirom binaries always get
-  built and added into recovery
-
+strike: - TODO: check for this flag in system/extras/multirom
+strike:   and libbootimg, and disable building them if the flag
+strike:   is not set, otherwise multirom binaries always get
+strike:   built and added into recovery
+fixed by sub77 here: https://github.com/Tasssadar/multirom/commit/1cad0efa84967a12ccaa7ffc4898d4808a3d0f67
 
 
 Folder changes
 ==============
-- move multirom files to separate sub-folder   recovery/multirom
+- move multirom files to separate sub-folder  recovery/multirom
 - move multirom specific prebuilts to         recovery/multirom/prebuilt  (1)
-- move multirom specific cp_xattrs to         recovery/multirom/cp_xattrs (1)
+- move multirom specific cp_xattrs to         recovery/multirom/cp_xattrs (1)(2)
+- move phablet folder to                      recovery/multirom/phablet   (1)
 Notes: (1) update/create Android.mk files
-
+       (2) update Android.mk to for proper relink
 
 
 multirom Code changes
@@ -33,9 +34,13 @@ multirom Code changes
 
 minzip Code changes
 ===================
-- add function 'read_data' needed by multirom in Zip.h and Zip.c
-- update Android.mk with build flag TARGET_RECOVERY_IS_MULTIROM
-Note: i guess this could get moved out of minzip and into multirom itself
+strike: - add function 'read_data' needed by multirom in Zip.h and Zip.c
+strike: - update Android.mk with build flag TARGET_RECOVERY_IS_MULTIROM
+strike: Note: i guess this could get moved out of minzip and into multirom itself
+- Update: the above is no longer true, minzip is no longer touched,
+  the read_data function has been moved to multirom_Zip.h and
+  multirom_Zip.c in the recovery/multirom folder
+  includes updated accordingly
 
 
 
@@ -45,6 +50,13 @@ gui Code changes
 - action.cpp    add multirom actions and functions
     Note: TW_ORS_IS_SECONDARY_ROM code moved to openrecoveryscript.cpp
 - update Android.mk with build flag TARGET_RECOVERY_IS_MULTIROM
+
+- fileselector.cpp   needed by multirom
+    + add <excludes> tag for multirom
+    + add support for multiple file extensions
+
+- listbox.cpp	add support for dynamic <items> tag
+
 
 
 main Code changes
@@ -75,6 +87,9 @@ main Code changes
 - update Android.mk
     + add new build flag TARGET_RECOVERY_IS_MULTIROM
     + add multirom source files, libraries, etc.
+
+- Note: code changes in twrp.cpp, partitions.hpp, partition.cpp, partitionmanager.cpp,
+        and twrp-functions(hpp/cpp), has been reordered for easier merges
 
 
 
@@ -116,7 +131,71 @@ General notes
 
 BUGS
 ====
-- is restorecon still broken? due to the -D flag in multirom.cpp
-    + #if PLATFORM_SDK_VERSION >= 21  #define RESTORECON_ARGS "-RFDv"
+strike: - is restorecon still broken? due to the -D flag in multirom.cpp
+strike:     + #if PLATFORM_SDK_VERSION >= 21  #define RESTORECON_ARGS "-RFDv"
+- Update: Android.mk has been updated to use toolbox restorecon if 
+          TARGET_RECOVERY_IS_MULTIROM is set
+
+TODO
+====
+* disable adb in second boot
+* fix workaround
+
+* delete_recursive("/tmp"); in installer script (eg HTC_One_M8_GPe_Marshmallow-6.0_MRA58K.H10_AROMA-Install.zip)
+* package_extract_xxx("", "/dev/block/.../by-name/system")
+
+* all the other stuff, i forgot
 
 
+
+New partitionlist type: "multirom_storage"
+==========================================
+In order to minimize code changes I reverted all migrations to full TWPartition 
+structure back to original multirom style "tw_multirom_install_loc" variable.
+
+Instead I just added additional support for the following variables:
+	tw_multirom_storage_path
+	tw_multirom_storage_display_name
+	tw_multirom_storage_free_size
+
+Now partitionmanager.cpp + gui/partitionlist.cpp supports new multirom_storage
+partitionlist:
+	<object type="partitionlist">
+		<data name="tw_multirom_storage_path" />
+		<listtype name="multirom_storage" />
+	</object>
+
+	<text>%tw_multirom_storage_display_name% (%tw_multirom_storage_free_size% MB)</text>
+
+So the following files/functions (amongst others), don't need to be patched:
+	multirom/multirom.h/cpp
+		static bool installLocNeedsImages(const std::string& loc);
+		static bool addROM(std::string zip, int os, std::string loc);
+		static bool setRomsPath(std::string loc);
+		static bool disableFlashKernelAct(std::string name, std::string loc);
+		static int getType(int os, std::string loc);
+
+	gui/action.cpp
+		GUIAction::multirom_reset_roms_paths
+		GUIAction::multirom_add
+		GUIAction::multirom_set_list_loc
+		GUIAction::multirom_list_loc_selected
+
+Instead, all changes have been added in:
+	partitionmanager.cpp
+	gui/partitionlist.cpp
+	multirom/multirom.cpp -> setRomsPath
+
+The core functions needed
+	TWPartitionManager::Update_tw_multirom_variables(TWPartition* partition);
+	TWPartitionManager::Update_tw_multirom_variables(std::string loc);
+allow for the coexistance of 'tw_multirom_storage_path' and original
+style 'tw_multirom_install_loc'.
+
+TWRP code will use 'tw_multirom_storage_path' however the underlying multirom code
+will still rely on "tw_multirom_install_loc" for flashing/etc.
+and visually "tw_multirom_storage_display_name" and "tw_multirom_storage_free_size"
+will be used to for properly GUI display.
+
+Completely unused, but kept for legacy:
+	std::string MultiROM::listInstallLocations();

--- a/partitionmanager.cpp
+++ b/partitionmanager.cpp
@@ -1931,6 +1931,76 @@ void TWPartitionManager::Get_Partition_List(string ListType, std::vector<Partiti
 				Partition_List->push_back(part);
 			}
 		}
+#ifdef TARGET_RECOVERY_IS_MULTIROM
+	} else if (ListType == "multirom_storage") {
+		Update_tw_multirom_variables(DataManager::GetStrValue("tw_multirom_install_loc").c_str());
+
+		char free_space[255];
+		string Current_Storage = DataManager::GetStrValue("tw_multirom_storage_path");
+		bool multirom_capable_storage;
+
+		for (iter = Partitions.begin(); iter != Partitions.end(); iter++) {
+			// what partitions are capable of being multirom_capabable_storage?
+			// all :D
+			// * has_data_media -> yes  (internal & adopted storage)
+			// * not on mmcblk0 -> yes  (external sd / ext4 partitions)
+			multirom_capable_storage = false;
+			multirom_capable_storage |= (*iter)->Has_Data_Media != 0;
+			multirom_capable_storage |= ((*iter)->Primary_Block_Device.compare(0, 18, "/dev/block/mmcblk0") != 0)
+										&& ((*iter)->Primary_Block_Device.compare(0, 14, "/dev/block/dm-"));
+
+			if (multirom_capable_storage) {
+				struct PartitionList part;
+				sprintf(free_space, "%llu", (*iter)->Free / 1024 / 1024);
+				part.Display_Name = (*iter)->Storage_Name + " (";
+				part.Display_Name += free_space;
+				part.Display_Name += "MB)";
+				part.Mount_Point = (*iter)->Storage_Path;
+				if ((*iter)->Storage_Path == Current_Storage)
+					part.selected = 1;
+				else
+					part.selected = 0;
+				Partition_List->push_back(part);
+			}
+/* Original MultiROM method from multirom.cpp (keep for reference):
+std::string MultiROM::listInstallLocations()
+{
+	std::string res = INTERNAL_MEM_LOC_TXT"\n";
+	blkid_probe pr;
+	const char *type;
+	struct dirent *dt;
+	char path[64];
+	DIR *d = opendir("/dev/block/");
+	if(!d)
+		return res;
+
+	while((dt = readdir(d)))
+	{
+		if(strncmp(dt->d_name, "mmcblk0", 7) == 0 || strncmp(dt->d_name, "dm-", 3) == 0)
+			continue;
+		snprintf(path, sizeof(path), "/dev/block/%s", dt->d_name);
+
+		pr = blkid_new_probe_from_filename(path);
+		if(!pr)
+			continue;
+
+		blkid_do_safeprobe(pr);
+		if (blkid_probe_lookup_value(pr, "TYPE", &type, NULL) >= 0)
+		{
+			res += "/dev/block/";
+			res += dt->d_name;
+			res += " (";
+			res += type;
+			res += ")\n";
+		}
+		blkid_free_probe(pr);
+	}
+	closedir(d);
+	return res;
+}
+*/
+		}
+#endif //TARGET_RECOVERY_IS_MULTIROM
 	} else if (ListType == "backup") {
 		char backup_size[255];
 		unsigned long long Backup_Size;
@@ -2403,6 +2473,70 @@ TWPartition* TWPartitionManager::Find_Original_Partition_By_Path(string Path) {
 			return (*iter);
 	}
 	return NULL;
+}
+
+// copy this from multirom.h to avoid include
+#define INTERNAL_MEM_LOC_TXT "Internal memory"
+
+bool TWPartitionManager::Update_tw_multirom_variables(TWPartition* partition) {
+	// Variables
+	// ---------
+	// tw_multirom_install_loc          -> (org) either "Internal memory" or "/dev/block/... (type)" eg
+	//                                                   USB-OTG = "/dev/block/sda1 (vfat)"
+	// tw_multirom_storage_path         -> (new) TWPartition->Storage_Path
+	// tw_multirom_storage_display_name -> (new) TWPartition->Storage_Name
+	// tw_multirom_storage_free_size    -> (new) TWPartition->Free
+	//
+	// in order to minimize code changes and preserve the original multirom code
+	// we'll just keep using all of the above variables
+
+	if (partition == NULL) {
+		//error, now what?
+		DataManager::SetValue("tw_multirom_storage_path", "");
+		DataManager::SetValue("tw_multirom_install_loc", "");
+		DataManager::SetValue("tw_multirom_storage_display_name", "");
+		DataManager::SetValue("tw_multirom_storage_free_size", "");
+		return false;
+	}
+
+	// tw_multirom_storage_path
+	DataManager::SetValue("tw_multirom_storage_path", partition->Storage_Path);
+
+	// tw_multirom_install_loc
+	std::string str;
+	if (partition->Is_Storage && partition->Is_Settings_Storage) {
+		str = INTERNAL_MEM_LOC_TXT;
+	} else {
+		str = partition->Actual_Block_Device + " (" + partition->Current_File_System + ")";
+	}
+	DataManager::SetValue("tw_multirom_install_loc", str);
+
+	// tw_multirom_storage_display_name and tw_multirom_storage_free_size
+	DataManager::SetValue("tw_multirom_storage_display_name", partition->Storage_Name);
+	char free_space[255];
+	sprintf(free_space, "%llu", partition->Free / 1024 / 1024);
+	DataManager::SetValue("tw_multirom_storage_free_size", free_space);
+
+	return true;
+}
+
+bool TWPartitionManager::Update_tw_multirom_variables(std::string loc) {
+	//location given, find the partition then fill
+	TWPartition* partition = NULL;
+
+	if(loc.compare(INTERNAL_MEM_LOC_TXT) == 0) {
+		// set partition to internal
+		partition = TWPartitionManager::Get_Default_Storage_Partition();
+	} else {
+		// find partition from "/dev/block/... (type)" style used by tw_multirom_install_loc
+		for (std::vector<TWPartition*>::iterator iter = Partitions.begin(); iter != Partitions.end(); iter++) {
+			if (loc.compare(0, (*iter)->Actual_Block_Device.size(), (*iter)->Actual_Block_Device) == 0) {
+				partition = (*iter);
+				break;
+			}
+		}
+	}
+	return Update_tw_multirom_variables(partition);
 }
 #endif //TARGET_RECOVERY_IS_MULTIROM
 

--- a/partitions.hpp
+++ b/partitions.hpp
@@ -290,6 +290,8 @@ public:
 	bool Push_Context();
 	void Copy_And_Push_Context();
 	bool Pop_Context();
+	bool Update_tw_multirom_variables(TWPartition* partition);
+	bool Update_tw_multirom_variables(std::string loc);
 	bool Has_Extra_Contexts() const { return !Contexts.empty(); }
 #endif //TARGET_RECOVERY_IS_MULTIROM
 	void Translate_Partition(const char* path, const char* resource_name, const char* default_value);


### PR DESCRIPTION
"multirom_storage" can be used in the theme xml's to mimic TWRPs native partition selection.

This adds support for the following new variables
- tw_multirom_storage_path
- tw_multirom_storage_display_name
- tw_multirom_storage_free_size

while keeping the original
- tw_multirom_install_loc

for the underlying multirom code.
