### PR TITLE
use 1080x1920 theme for 720x1280 devices too

### DIFF
--- a/gui/Android.mk
+++ b/gui/Android.mk
@@ -98,7 +98,7 @@ TWRP_NEW_THEME := true
 ifeq ($(TW_CUSTOM_THEME),)
 ifeq ($(TARGET_RECOVERY_IS_MULTIROM),true)
     MR_THEME := $(DEVICE_RESOLUTION)
-    ifeq ($(MR_THEME),1440x2560)
+    ifeq ($(filter-out 1440x2560 720x1280,$(MR_THEME)),)
         MR_THEME := 1080x1920
     endif
 


### PR DESCRIPTION
The Sony Xperia Z3 Compact for example is using a 720x1280 screen, and can use the 1080x1920 theme just fine.
